### PR TITLE
Checking for valid input before save dialog appears

### DIFF
--- a/Route Visualizer/Form1.resx
+++ b/Route Visualizer/Form1.resx
@@ -1756,13 +1756,13 @@
     <value>Save &amp;Layers Separately</value>
   </data>
   <data name="SingleFilesToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 22</value>
+    <value>152, 22</value>
   </data>
   <data name="SingleFilesToolStripMenuItem.Text" xml:space="preserve">
     <value>Single Files</value>
   </data>
   <data name="GIFToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 22</value>
+    <value>152, 22</value>
   </data>
   <data name="GIFToolStripMenuItem1.Text" xml:space="preserve">
     <value>GIF</value>


### PR DESCRIPTION
Valid input: selected zoom, number of route files with visibility true
and line width > 0, number of checked layers, etc.
